### PR TITLE
2018/05/30 と 2018/05/31 分を追加

### DIFF
--- a/2018/05/30.md
+++ b/2018/05/30.md
@@ -1,6 +1,6 @@
 # 2019/05/30 今日のるびぃ
 
-## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (12) ~
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (13) ~
 
 [REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
 

--- a/2018/05/30.md
+++ b/2018/05/30.md
@@ -1,0 +1,223 @@
+# 2019/05/30 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (12) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### Enumerator クラス, Enumerable クラス, String クラス, Object クラス
+
+以下のプログラムを実行すると, `ruby` が一文字ずつ表示される.
+`each_char` を置き換えても同じ結果になるメソッドを選択肢から選ぶ.
+
+```ruby
+enum = 'ruby'.each_char
+p enum.next
+p enum.next
+p enum.next
+p enum.next
+```
+
+とりあえず, 上記を irb で試す.
+
+```ruby
+irb(main):001:0> enum = 'ruby'.each_char
+=> #<Enumerator: "ruby":each_char>
+irb(main):002:0> p enum.next
+"r"
+=> "r"
+irb(main):003:0> p enum.next
+"u"
+=> "u"
+irb(main):004:0> p enum.next
+"b"
+=> "b"
+irb(main):005:0> p enum.next
+"y"
+=> "y"
+irb(main):001:0> enum = 'ruby'.enum_for(:each_char)
+=> #<Enumerator: "ruby":each_char>
+irb(main):002:0> p enum.next
+"r"
+=> "r"
+irb(main):003:0> p enum.next
+"u"
+=> "u"
+irb(main):004:0> p enum.next
+"b"
+=> "b"
+irb(main):005:0> p enum.next
+"y"
+=> "y"
+```
+
+ちなみに, `String#next` や `Integer#next` は, それぞれ `succ` メソッドをエイリアスとして利用可能であるが, `Enumerator#next` には `succ` は存在しないので注意する.
+
+ということで, 解答.
+
+> to_enum(:each_char)
+> enum_for(:each_char)
+
+以下, irb で確認.
+
+```ruby
+irb(main):006:0> enum = 'ruby'.to_enum(:each_char)
+=> #<Enumerator: "ruby":each_char>
+irb(main):007:0> p enum.next
+"r"
+=> "r"
+irb(main):008:0> p enum.next
+"u"
+=> "u"
+irb(main):009:0> p enum.next
+"b"
+=> "b"
+irb(main):010:0> p enum.next
+"y"
+=> "y"
+```
+
+以下, 解説より抜粋.
+
+* `each_char` にブロックを渡さない場合は, `Enumerator` オブジェクトが作成される
+* `Enumerator` オブジェクトを作成するには, `enum_for` または, `to_enum` を利用する
+* 引数にはレシーバーに送信したいメッセージ （メソッドの呼び出し） を定義する
+* 引数を指定しない場合は, `each` がデフォルト値になる
+
+次の例では、eachを使って１つずつアクセスして要素を表示しています。
+
+```ruby
+irb(main):001:0> enum = [1, 2, 3, 4, 5].to_enum
+=> #<Enumerator: [1, 2, 3, 4, 5]:each>
+irb(main):002:0> p enum.next
+1
+=> 1
+irb(main):003:0> p enum.next
+2
+=> 2
+irb(main):004:0> p enum.next
+3
+=> 3
+irb(main):005:0> p enum.next
+4
+=> 4
+irb(main):006:0> p enum.next
+5
+=> 5
+irb(main):001:0> enum = [1, 2, 3, 4, 5].enum_for(:reverse_each)
+=> #<Enumerator: [1, 2, 3, 4, 5]:reverse_each>
+irb(main):002:0> p enum.next
+5
+=> 5
+irb(main):003:0> p enum.next
+4
+=> 4
+irb(main):004:0> p enum.next
+3
+=> 3
+irb(main):005:0> p enum.next
+2
+=> 2
+irb(main):006:0> p enum.next
+1
+=> 1
+```
+
+### 例外
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+begin
+  print "foo" + :bar
+rescue TypeError
+  print "TypeError."
+rescue
+  print "Error."
+else
+  print "Else."
+end
+```
+
+> TypeError. が表示される
+
+以下, irb による確認.
+
+```ruby
+irb(main):001:0> begin
+irb(main):002:1*   print "foo" + :bar
+irb(main):003:1> rescue TypeError
+irb(main):004:1>   print "TypeError."
+irb(main):005:1> rescue
+irb(main):006:1>   print "Error."
+irb(main):007:1> else
+irb(main):008:1*   print "Else."
+irb(main):009:1> end
+TypeError.=> nil
+```
+
+以下, 解説より抜粋.
+
+* `String#+` は `String` クラスのオブジェクトを期待する
+* 引数に `Symbol` クラスを渡している為, 例外 `TypeError` が発生する 
+* `else` ブロックは例外が発生しない場合に実行される
+
+ちなみに, 以下のように書くとどうなるか.
+
+```ruby
+begin
+  print "foo" + :bar
+rescue TypeError
+  print "TypeError."
+rescue
+  print "Error."
+else
+  print "Else."
+ensure
+  print "Ensure."
+end
+```
+
+> Type Error. と Ensure. が出力される
+
+以下, irb による実行例.
+
+```ruby
+irb(main):001:0> begin
+irb(main):002:1*   print "foo" + :bar
+irb(main):003:1> rescue TypeError
+irb(main):004:1>   print "TypeError."
+irb(main):005:1> rescue
+irb(main):006:1>   print "Error."
+irb(main):007:1> else
+irb(main):008:1*   print "Else."
+irb(main):009:1> ensure
+irb(main):010:1*   print "Ensure."
+irb(main):011:1> end
+TypeError.Ensure.=> nil
+```
+
+`ensure` ブロックは例外の発生関わらず, 必ず実行されるので, このコードにおいて例外が発生しない場合には, else 及び ensure ブロックまで含まれる出力となる.
+
+```ruby
+irb(main):001:0> begin
+irb(main):002:1*   print "foo" + 'bar'
+irb(main):003:1> rescue TypeError
+irb(main):004:1>   print "TypeError."
+irb(main):005:1> rescue
+irb(main):006:1>   print "Error."
+irb(main):007:1> else
+irb(main):008:1*   print "Else."
+irb(main):009:1> ensure
+irb(main):010:1*   print "Ensure."
+irb(main):011:1> end
+foobarElse.Ensure.=> nil
+```
+
+ﾌﾑﾌﾑ.

--- a/2018/05/31.md
+++ b/2018/05/31.md
@@ -1,0 +1,126 @@
+# 2019/05/31 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (14) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### 定数
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+m = Module.new
+
+m.module_eval do
+  EVAL_CONST = 100
+end
+
+puts "CONST is defined? #{m.const_defined?(:CONST)}"
+puts "_CONST is defined? #{Object.const_defined?(:CONST)}"
+```
+
+> CONST is defined? true
+> CONST is defined? true
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> m = Module.new
+=> #<Module:0x0055719c3d4f88>
+irb(main):002:0> 
+irb(main):003:0* m.module_eval do
+irb(main):004:1*   CONST = 100
+irb(main):005:1> end
+=> 100
+irb(main):006:0> 
+irb(main):007:0* puts "CONST is defined? #{m.const_defined?(:CONST)}"
+EVAL_CONST is defined? true
+=> nil
+irb(main):008:0> puts "CONST is defined? #{Object.const_defined?(:CONST)}"
+EVAL_CONST is defined? true
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* 設問において, `module_eval` のブロックで定義した定数はこの問題ではトップレベルで定義したことになる
+* 定数 `EVAL_CONST` はトップレベルで定義していることになる為, Object クラスの定数あることであることを確認出来る
+* `Module` クラスのインスタンスには直接, 定数は定義されていないが継承関係を探索して参照することが可能
+* `const_defined?` メソッドは第二引数に継承関係を探索するか指定が可能である為, 継承関係を探索するかによって結果は異なる
+
+```ruby
+irb(main):001:0> m = Module.new
+=> #<Module:0x0055f166098fa0>
+irb(main):002:0> m.module_eval do
+irb(main):003:1*   CONST = 'foo'
+irb(main):004:1> end
+=> "foo"
+irb(main):005:0> puts Object.const_defined?(:CONST)
+true
+=> nil
+irb(main):006:0> puts m.const_defined?(:CONST)
+true
+=> nil
+irb(main):007:0> puts m.const_defined?(:CONST, false)
+false
+=> nil
+```
+
+ちなみに, 設問において, `module_eval` で文字列でメソッドを定義した場合には以下のような挙動になる.
+
+```ruby
+irb(main):001:0> m = Module.new
+=> #<Module:0x0056220dff5138>
+irb(main):002:0> m.module_eval %Q{
+irb(main):003:0"   CONST = 'foo'
+irb(main):004:0" } 
+=> "foo"
+irb(main):005:0> puts Object.const_defined?(:CONST)
+false
+=> nil
+irb(main):006:0> puts m.const_defined?(:CONST)
+true
+=> nil
+irb(main):007:0> puts m.const_defined?(:CONST, false)
+true
+=> nil
+```
+
+`module_eval` や `calss_eval` において, メソッドを文字列で渡すかブロックで渡すかによって定数とクラス変数のスコープは異なるので注意が必要となる. 上記の例だと, 定数は module m 内に定義されていることになる.
+
+ところで, Module.new って出来るんだ...ということで, 以下, ドキュメントより抜粋.
+
+* Module.new
+    * 名前の付いていないモジュールを新しく生成して返す
+    * ブロックが与えられると生成したモジュールをブロックに渡し, モジュールのコンテキストでブロックを実行する
+
+```ruby
+mod = Module.new
+mod.module_eval {|m| ... }
+mod
+```
+
+また, このメソッドで生成されたモジュールは, 最初に名前が必要になった時に名前が決定する
+
+```ruby
+mod = Module.new
+mod.module_eval {|m| ... }
+mod
+
+m = Module.new
+p m               # => #<Module 0lx40198a54>
+p m.name          # => nil   # まだ名前は未定
+Foo = m
+# m.name          # ここで m.name を呼べば m の名前は "Foo" に確定する
+Bar = m
+m.name            # "Foo" か "Bar" のどちらかに決まる
+```
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* `Enumerator` オブジェクトを作成するには, `enum_for` または, `to_enum` を利用する
* `enum_for` または, `to_enum` の引数には, レシーバに送信したいメソッドを定義する, 引数を定義しない場合には `each` が定義される
* `begin ~ rescue` において, `else` は例外が発生しなかった場合, `ensure` は例外の有無に関わらず実行される
* `Module.new` でインスタンス化出来る
* トップレベルで定義した定数は `Object` クラスの定数となる