### PR TITLE
2018/06/05 分を追加

### DIFF
--- a/2018/06/05.md
+++ b/2018/06/05.md
@@ -1,0 +1,175 @@
+# 2019/06/05 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (19) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### String#scan と 正規表現
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+p "Matz is my tEacher".scan(/[is|my]/).size
+```
+
+> 4 と表示される
+
+以下, irb による確認.
+
+```ruby
+irb(main):001:0> p "Matz is my tEacher".scan(/[is|my]/).size
+4
+=> 4
+```
+
+以下, 解説より抜粋.
+
+* `String#scan` はマッチした部分文字列を配列で返す
+* 正規表現の `[]` は囲まれた**文字 1 つ 1 つ**にマッチする
+* `|` は正規表現では `OR` のメタ文字である
+* 設問では |が[]に囲まれているため, これもマッチ対象となる
+
+以下, 改めて, irb にて確認.
+
+```ruby
+# String#scan でマッチした文字列を配列で返している
+irb(main):002:0> p "Matz is my tEacher".scan(/[is|my]/)
+["i", "s", "m", "y"]
+=> ["i", "s", "m", "y"]
+# Array#size でマッチした結果の size (length) で要素数を返す
+irb(main):004:0> p "Matz is my tEacher".scan(/[is|my]/).class
+Array
+=> Array
+irb(main):005:0> p "Matz is my tEacher".scan(/[is|my]/).size
+4
+=> 4
+irb(main):006:0> p "Matz is my tEacher".scan(/[is|my]/).length
+4
+=> 4
+```
+
+以下, String#scan の実行例.
+
+```ruby
+irb(main):007:0> p "foobar".scan(/../)     
+["fo", "ob", "ar"]
+=> ["fo", "ob", "ar"]
+irb(main):008:0> p "foobar".scan("o")
+["o", "o"]
+=> ["o", "o"]
+irb(main):009:0> p "foobarbazfoobarbaz".scan(/ba./)
+["bar", "baz", "bar", "baz"]
+=> ["bar", "baz", "bar", "baz"]
+irb(main):010:0> p "foobar".scan(/./)
+["f", "o", "o", "b", "a", "r"]
+=> ["f", "o", "o", "b", "a", "r"]
+irb(main):011:0> p "foobar".scan(/(.)/)
+[["f"], ["o"], ["o"], ["b"], ["a"], ["r"]]
+=> [["f"], ["o"], ["o"], ["b"], ["a"], ["r"]]
+irb(main):012:0> p "foobarbazfoobarbaz".scan(/(ba)(.)/)
+[["ba", "r"], ["ba", "z"], ["ba", "r"], ["ba", "z"]]
+=> [["ba", "r"], ["ba", "z"], ["ba", "r"], ["ba", "z"]]
+```
+
+### アクセサメソッド
+
+以下のコードで指定した行を書き換えた時，同じ結果になるものを選ぶ.
+
+```ruby
+class C
+  attr_accessor :v # ここを書き換える
+end
+
+c = C.new
+c.v = 100
+p c.v
+```
+
+以下, 解答.
+
+```ruby
+# パターン 1
+attr_reader :v
+attr_writer :v
+
+# パターン 2
+def v=(other)
+  @v = other
+end
+def v
+  @v
+end
+```
+
+以下, irb による確認.
+
+```ruby
+# 設問コード
+irb(main):001:0> class C
+irb(main):002:1>   attr_accessor :v
+irb(main):003:1> end
+=> nil
+irb(main):004:0> 
+irb(main):005:0* c = C.new
+=> #<C:0x00561953649a48>
+irb(main):006:0> c.v = 100
+=> 100
+irb(main):007:0> p c.v
+100
+=> 100
+# 解答 (1)
+irb(main):008:0> class C
+irb(main):009:1>   attr_reader :v
+irb(main):010:1>   attr_writer :v  
+irb(main):011:1> end
+=> nil
+irb(main):012:0> 
+irb(main):013:0* c = C.new
+=> #<C:0x005619535fcf18>
+irb(main):014:0> c.v = 100
+=> 100
+irb(main):015:0> p c.v
+100
+=> 100
+# 解答 (2)
+irb(main):016:0> class C
+irb(main):017:1>   def v=(other)
+irb(main):018:2>     @v = other
+irb(main):019:2>   end
+irb(main):020:1>   def v
+irb(main):021:2>     @v
+irb(main):022:2>   end
+irb(main):023:1> end
+=> :v
+irb(main):024:0> 
+irb(main):025:0* c = C.new
+=> #<C:0x005619535b1888>
+irb(main):026:0> c.v = 100
+=> 100
+irb(main):027:0> p c.v
+100
+=> 100
+```
+
+以下, 解説より抜粋.
+
+* `attr_accessor` は `attr_reader` と `attr_writer` を同時に定義する
+* `attr_reader` と `attr_writer` は, 以下のようにも定義出来る
+
+```ruby
+def v=(other)
+  @v = other
+end
+def v
+  @v
+end
+```
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* String#scan はマッチした部分文字列を配列で返す

```ruby
irb(main):028:0> 'foobarbaz'.scan(/foo/)
=> ["foo"]
irb(main):029:0> 'foobarbaz'.scan(/[foo]/)
=> ["f", "o", "o"]
```

* Array#size と Array#length は同義
* attr_accessor は attr_reader と attr_writer を同時に定義する
* attr_reader と attr_writer は以下のようにも書ける

```ruby
def v=(other)
  @v = other
end
def v
  @v
end
```