### PR TITLE
2018/06/09 分を追加

### DIFF
--- a/2018/06/09.md
+++ b/2018/06/09.md
@@ -1,0 +1,176 @@
+# 2019/06/09 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (23) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### モジュール, クラスのネスト
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+# コード 1
+class Cls1
+  p Module.nesting
+end
+
+# コード 2
+module Mod
+  class ::Cls1
+    p Module.nesting
+  end
+end
+
+# コード 3
+module Mod
+  class Cls1
+    p Module.nesting
+  end
+end
+```
+
+> コード 1 は [Cls1] と表示される
+> コード 2 は [Cls1, Mod] と表示される
+> コード 3 は [Mod::Cls1, Mod] と表示される
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> class Cls1
+irb(main):002:1>   p Module.nesting
+irb(main):003:1> end
+[Cls1]
+=> [Cls1]
+irb(main):004:0> 
+irb(main):005:0* module Mod
+irb(main):006:1>   class ::Cls1
+irb(main):007:2>     p Module.nesting
+irb(main):008:2>   end
+irb(main):009:1> end
+[Cls1, Mod]
+=> [Cls1, Mod]
+irb(main):010:0> 
+irb(main):011:0* module Mod
+irb(main):012:1>   class Cls1
+irb(main):013:2>     p Module.nesting
+irb(main):014:2>   end
+irb(main):015:1> end
+[Mod::Cls1, Mod]
+=> [Mod::Cls1, Mod]
+```
+
+以下, 解説より抜粋.
+
+* 先頭に `::` がある場合はモジュール内にあっても, トップレベルのクラス `Cls1` と同義である
+* `Mod::Cls1` の場合はトップレベルのクラス `Cls1` とは別のものとなる
+
+`Module.nesting` について, ドキュメントより引用.
+
+* このメソッドを呼び出した時点でのクラス/モジュールのネスト情報を配列に入れて返す
+
+```ruby
+module Foo
+  module Bar
+    module Baz
+      p Module.nesting   # => [Foo::Bar::Baz, Foo::Bar, Foo]
+    end
+  end
+end
+```
+
+### インスタンス変数の可視性
+
+以下のコードで指定した行を書き換えた際に同じ結果になるものを選ぶ. (複数選択)
+
+```ruby
+class Cls1
+  def v=(other) # ここから
+    @v = other
+  end
+  def v
+    @v
+  end           # ここまで
+end
+
+c = Cls1.new
+c.v = 100
+p c.v
+```
+
+以下, 解答.
+
+```ruby
+# 解答 1
+attr_reader :v
+attr_writer :v
+
+# 解答 2
+attr_accessor :v
+```
+
+以下, irb にて確認.
+
+```ruby
+# 設問
+irb(main):001:0> class Cls1
+irb(main):002:1>   def v=(other)
+irb(main):003:2>     @v = other
+irb(main):004:2>   end
+irb(main):005:1>   def v
+irb(main):006:2>     @v
+irb(main):007:2>   end 
+irb(main):008:1> end
+=> :v
+irb(main):009:0> 
+irb(main):010:0* c = Cls1.new
+=> #<Cls1:0x00564834342790>
+irb(main):011:0> c.v = 100
+=> 100
+irb(main):012:0> p c.v
+100
+=> 100
+
+# 解答 1
+irb(main):001:0> class Cls1
+irb(main):002:1>   attr_reader :v
+irb(main):003:1>   attr_writer :v
+irb(main):004:1> end
+=> nil
+irb(main):005:0> 
+irb(main):006:0* c = Cls1.new
+=> #<Cls1:0x00559c70e8ad70>
+irb(main):007:0> c.v = 100
+=> 100
+irb(main):008:0> p c.v
+100
+=> 100
+
+# 解答 2
+irb(main):001:0> class Cls1
+irb(main):002:1>   attr_accessor :v
+irb(main):003:1> end
+=> nil
+irb(main):004:0> 
+irb(main):005:0* c = Cls1.new
+=> #<Cls1:0x00557406645710>
+irb(main):006:0> c.v = 100
+=> 100
+irb(main):007:0> p c.v
+100
+=> 100
+```
+
+以下, 解説より抜粋.
+
+* `attr_reader` はインスタンス変数を返すメソッド (def v\ end) を作成する
+* `attr_writer` はインスタンス変数を変更するメソッド (def v=\ end) を作成する
+* `attr_accessor` はインスタンス変数を返すメソッドと変更するメソッドを作成する
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* 先頭に `::` がある場合はモジュール内にあっても, トップレベルに定義しているクラスと同義である
* `attr_reader` はインスタンス変数を返すメソッド (def v\ end) を作成する
* `attr_writer` はインスタンス変数を変更するメソッド (def v=\ end) を作成する
* `attr_accessor` はインスタンス変数を返すメソッドと変更するメソッドを作成する