### PR TITLE
2018/06/14 分を追加

### DIFF
--- a/2018/06/14.md
+++ b/2018/06/14.md
@@ -1,0 +1,124 @@
+# 2019/06/14 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (26) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### Mix-in
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+module M
+  def class_m
+    "class_m"
+  end
+end
+
+class C
+  include M
+end
+
+p C.methods.include? :class_m
+```
+
+> false
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> module M
+irb(main):002:1>   def class_m
+irb(main):003:2>     "class_m"
+irb(main):004:2>   end
+irb(main):005:1> end
+=> :class_m
+irb(main):006:0> 
+irb(main):007:0* class C
+irb(main):008:1>   include M
+irb(main):009:1> end
+=> C
+irb(main):010:0> 
+irb(main):011:0* p C.methods.include? :class_m
+false
+=> false
+```
+
+以下, 解説より抜粋.
+
+* `include` は Module のインスタンスメソッドを Mix-in するメソッド
+* C.methods は C の特異メソッドを表示する
+
+従って, `C#class_m` はインスタンスメソッドとなり, `C.methods` では表示されないが, 以下のようにインスタンス化することで, `true` インスタンスメソッドとなり `true` となる.
+
+```ruby
+irb(main):012:0> p C.new.methods.include? :class_m
+true
+=> true
+```
+
+### インスタンスメソッド, 特異メソッド
+
+以下のコードを実行するとどうなるか.
+
+```ruby
+class Cls
+  class << Cls
+    def foo
+      'foo'
+    end
+  end
+
+  def foo
+    'FOO'
+  end
+end
+
+p Cls.new.foo
+```
+
+> FOO
+
+以下, irb による確認.
+
+```ruby
+irb(main):001:0> class Cls
+irb(main):002:1>   class << Cls
+irb(main):003:2>     def foo
+irb(main):004:3>       'foo'
+irb(main):005:3>     end
+irb(main):006:2>   end
+irb(main):007:1> 
+irb(main):008:1*   def foo
+irb(main):009:2>     'FOO'
+irb(main):010:2>   end
+irb(main):011:1> end
+=> :foo
+irb(main):012:0> 
+irb(main):013:0* p Cls.new.foo
+"FOO"
+=> "FOO"
+```
+
+以下, 解説より抜粋.
+
+* 特異クラス内 `class << Cls; end` に宣言されたメソッドは特異メソッドとなる
+* 特異メソッドは `def Cls.foo: end` でも宣言することも出来る
+* 設問コードでは, インスタンスを作成しそのメソッドを呼び出している為, インスタンスメソッドの FOO を返すメソッドが呼ばれる
+
+以下のように書くと `foo` が出力される.
+
+```ruby
+irb(main):014:0> p Cls.foo
+"foo"
+=> "foo"
+```
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* `include` は Module のインスタンスメソッドを Mix-in するメソッド
* 特異クラス内 `class << Cls; end` に宣言されたメソッドは特異メソッドとなる
* 特異メソッドは `def Cls.foo: end` でも宣言することも出来る