### PR TITLE
2018/06/15 分を追加

### DIFF
--- a/2018/06/15.md
+++ b/2018/06/15.md
@@ -1,0 +1,92 @@
+# 2019/06/15 今日のるびぃ
+
+## 今日のるびぃ ~ REx - Ruby Examination にチャレンジ (27) ~
+
+[REx - Ruby Examination](https://rex.libertyfish.co.jp/) の問題を自分なりにアレンジした上で 1 〜 3 問くらいずつ解いていく. 正直言ってかなり難しい. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### Ruby コマンドラインオプション
+
+Ruby で使用可能なオプション**ではないもの**を選択する.
+
+* `-t`
+* `-l`
+* `-p`
+* `-f`
+
+以下, 利用可能ではないオプション.
+
+* `-t`
+* `-f`
+
+以下, 利用可能なオプション (解説より抜粋)
+
+* `-l`
+    * 各行の最後に `String#chop!` を実行する (ドキュメントより引用: 行末の自動処理を行います。まず、$\ を $/ と同じ値に設定し, printでの出力 時に改行を付加するようにします。)
+* `-p`
+    * `-n` オプションと同様に `$_` を出力する
+    * `$_` とは, `最後に Kernel.#gets または Kernel.#readline で読み込んだ文字列です。` (ドキュメントより引用)
+
+以下, 実行例.
+
+```sh
+# 通常は print を利用する場合, 改行は付加されない
+$ ruby -e 'print "01234567890"'
+01234567890$
+# -l オプションを付けると, print を利用した際に改行を付加する
+$ ruby -l -e 'print "01234567890"'
+01234567890
+# -p オプションのサンプル
+$ echo foo | ruby -p -e '$_.tr! "a-z", "A-Z"'
+FOO
+# ちなみに, -n オプションは以下のような挙動となる
+$ echo 'foo' | ruby -n -e 'print'
+foo
+```
+
+### Enumerator::Lazy
+
+以下のコードは `Enumerator::Lazy` を利用している. 先頭から 5 つの値を取り出す為にはどのメソッドが必要か.
+
+```ruby
+(1..100).each.lazy.chunk(&:even?)
+```
+
+以下, 解答.
+
+> take(5).force
+> first(5)
+
+以下, irb による実行例.
+
+```ruby
+irb(main):001:0> (1..100).each.lazy.chunk(&:even?)
+=> #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x0055758c2a6dc0>:each>>
+irb(main):002:0> (1..100).each.lazy.chunk(&:even?).first(5)
+=> [[false, [1]], [true, [2]], [false, [3]], [true, [4]], [false, [5]]]
+irb(main):003:0> (1..100).each.lazy.chunk(&:even?).take(5)
+=> #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x0055758c24f048>:each>>:take(5)>
+irb(main):004:0> (1..100).each.lazy.chunk(&:even?).take(5).force
+=> [[false, [1]], [true, [2]], [false, [3]], [true, [4]], [false, [5]]]
+irb(main):006:0> (1..100).each.lazy.chunk(&:even?).force.take(5)
+=> [[false, [1]], [true, [2]], [false, [3]], [true, [4]], [false, [5]]]
+irb(main):007:0> (1..100).each.lazy.chunk(&:even?).first
+=> [false, [1]]
+irb(main):008:0> (1..100).each.lazy.chunk(&:even?).force.first(5)
+=> [[false, [1]], [true, [2]], [false, [3]], [true, [4]], [false, [5]]]
+```
+
+以下, 解説より抜粋.
+
+* 単純に値を取り出すには, `Enumerator::Lazy#force` 又は `Enumerator::Lazy#first` を利用する
+* 設問では, 「先頭から 5 つの値」とあるので, `first(5)` を利用する
+* `Enumerator::Lazy#force` は全ての値を取り出す (全ての要素を含む配列を返す) が, 5 つの値を取り出す為には `Enumerator::Lazy#take` 又は `Enumerator::Lazy#first` を利用する
+* `Enumerator::Lazy#take` は `Enumerable#take` と異なり, `Enumerator::Lazy` のインスタンスを戻り値となる為, `Enumerator::Lazy#force` で実際の値を取り出す
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* `-t` とか `-f` という Ruby のコマンドラインオプションは存在しない
* `Enumerator::Lazy` クラスのオブジェクトから値を取り出す場合, `force` 又は `first` メソッドを利用する
    * `force` は全ての値を取り出す
    * `first` は, 先頭から引数に指定した個数分を取り出す