### PR TITLE
2018/07/24 分を追加

### DIFF
--- a/2018/07/24.md
+++ b/2018/07/24.md
@@ -1,0 +1,184 @@
+# 2018/07/24 今日のるびぃ
+
+## 今日のるびぃ ~ Ruby 技術者認定試験合格教本 （Silver/Gold 対応） Ruby 公式資格教科書 模擬試験 (14) 文法 (4) ~
+
+irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### 文法 (11)
+
+Q29. 以下のコードを実行した場合はどうなるか.
+
+```ruby
+a, b, c = [1, 2]
+puts a
+puts b
+puts c
+```
+
+以下, 解答.
+
+> 1.
+> 1
+> 2
+> nil
+
+以下, irb にて確認.
+
+```ruby
+irb(main):003:0> a, b, c = [1, 2]
+=> [1, 2]
+irb(main):004:0> puts a
+1
+=> nil
+irb(main):005:0> puts b
+2
+=> nil
+irb(main):006:0> puts c
+
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* 多重代入において左辺の要素数が右辺より多い場合, 余った左辺の要素には `nil` が代入される
+
+以下, 多重代入をお試し.
+
+```ruby
+irb(main):016:0> a, b = [1, 2, 3]
+=> [1, 2, 3]
+irb(main):017:0> p a
+1
+=> 1
+irb(main):018:0> p b
+2
+=> 2
+irb(main):019:0> a, *b = [1, 2, 3]
+=> [1, 2, 3]
+irb(main):020:0> p a
+1
+=> 1
+irb(main):021:0> p b
+[2, 3]
+=> [2, 3]
+irb(main):022:0> a, *b, c = [1, 2, 3]
+=> [1, 2, 3]
+irb(main):023:0> p a
+1
+=> 1
+irb(main):025:0> p b
+[2]
+=> [2]
+irb(main):026:0> p c
+3
+=> 3
+irb(main):027:0> *a, b, c = [1, 2, 3]
+=> [1, 2, 3]
+irb(main):028:0> p a
+[1]
+=> [1]
+irb(main):029:0> p b
+2
+=> 2
+irb(main):030:0> p c
+3
+=> 3
+```
+
+### 文法 (12)
+
+Q32. 以下の実行結果になるように, [ x ] に記述する適切なコードを全て選べ.
+
+```ruby
+# コード
+class Err1 < StandardError; end
+class Err2 < Err1; end
+
+begin
+  [ x ]
+rescue Err1 => ex
+  puts 'Error'
+end
+
+# 実行結果
+Error
+```
+
+以下, 解答.
+
+> 2. raise Err1
+> 3. raise Err2
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> class Err1 < StandardError; end
+=> nil
+irb(main):002:0> class Err2 < Err1; end
+=> nil
+irb(main):003:0> 
+irb(main):004:0* begin
+irb(main):005:1*   raise Err1
+irb(main):006:1> rescue Err1 => ex
+irb(main):007:1>   puts 'Error'
+irb(main):008:1> end
+Error
+=> nil
+irb(main):009:0> begin
+irb(main):010:1*   raise Err2
+irb(main):011:1> rescue Err1 => ex
+irb(main):012:1>   puts 'Error'
+irb(main):013:1> end
+Error
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* 設問コードの `rescue Err1` は, `Err1` と `Err1` のサブクラス (`Err2`) の例外を捕捉する
+
+以下, 設問をちょっと弄ってみた.
+
+```ruby
+# StandardError を発生させた場合, 捕捉されない
+irb(main):014:0> begin
+irb(main):015:1*   raise StandardError
+irb(main):016:1> rescue Err1 => ex
+irb(main):017:1>   puts 'Error'
+irb(main):018:1> end
+StandardError: StandardError
+...
+# StandardError を発生させて, StandardError を rescue させると当然, 例外が把捉される.
+irb(main):019:0> begin
+irb(main):020:1*   raise StandardError
+irb(main):021:1> rescue StandardError => ex
+irb(main):022:1>   puts 'Error'
+irb(main):023:1> end
+Error
+=> nil
+# Err1 を発生させて, StandardError で rescue すると, 例外が捕捉される (Standard Error を継承しているから)
+irb(main):024:0> begin
+irb(main):025:1*   raise Err1
+irb(main):026:1> rescue StandardError => ex
+irb(main):027:1>   puts 'Error'
+irb(main):028:1> end
+Error
+=> nil
+# 同様に Err2 を発生させて, StandardError で rescue すると, 例外が捕捉される (Standard Error を継承しているから)
+irb(main):029:0> begin
+irb(main):030:1*   raise Err2
+irb(main):031:1> rescue StandardError => ex
+irb(main):032:1>   puts 'Error'
+irb(main):033:1> end
+Error
+=> nil
+```
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* 多重代入において左辺の要素数が右辺より多い場合, 余った左辺の要素には `nil` が代入される
* 例外クラスとそのサブクラスが rescue で捕捉される

```ruby
class Err1 < StandardError; end
class Err2 < Err1; end
begin
  raise Err2
rescue Err1 => ex
  p ex.class
end #=> Err2
```