### PR TITLE
2018/07/25 分を追加

### DIFF
--- a/2018/07/25.md
+++ b/2018/07/25.md
@@ -1,0 +1,158 @@
+# 2018/07/25 今日のるびぃ
+
+## 今日のるびぃ ~ Ruby 技術者認定試験合格教本 （Silver/Gold 対応） Ruby 公式資格教科書 模擬試験 (15) 文法 (5) ~
+
+irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### 文法 (13)
+
+Q35. 可変長引数について適切な記述を選べ.
+
+以下, 解答.
+
+>3. 可変長引数には `*` を付ける
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> def foo(*arg)
+irb(main):002:1>   p arg.class
+irb(main):003:1>   p arg
+irb(main):004:1>   p *arg
+irb(main):005:1> end
+=> :foo
+irb(main):006:0> foo(1, 2, 3, 4, 5)
+Array
+[1, 2, 3, 4, 5]
+1
+2
+3
+4
+5
+=> [1, 2, 3, 4, 5]
+irb(main):007:0> 
+```
+
+以下, 解説より抜粋.
+
+* 可変長引数にはデフォルト値の指定出来ない
+* 引数は配列として扱われる
+* 可変長引数は一つのメソッドに一つしか指定出来ない
+
+### 文法 (14) 以降は, 基礎力確認問題を解く
+
+Q2. 以下のコードを実行すると何が表示されるか.
+
+```ruby
+x, *y = *[0, 1, 2]
+p x, y
+```
+
+以下, 解答.
+
+> 1. 0 <改行> [1, 2]
+
+以下, irb にて確認.
+
+```ruby
+irb(main):007:0> x, *y = *[0, 1, 2]
+=> [0, 1, 2]
+irb(main):008:0> p x, y
+0
+[1, 2]
+=> [0, [1, 2]]
+```
+
+* 多重代入
+* 右辺の `*` は無視して構わない
+* 左辺の `x` には, 配列の最初の要素が格納され, `y` には `*` が付いているので残りの要素が配列として格納される
+
+### 文法 (15)
+
+Q3. [ x ] に記述すると, 以下の実行結果にならないコードを全て選べ.
+
+```ruby
+# コード
+puts [ x ]
+
+# 実行結果
+0.8
+```
+
+以下, 解答.
+
+> 1. 4/5
+> 3. 4/5r
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> 4/5
+=> 0
+irb(main):002:0> 4.0/5
+=> 0.8
+irb(main):003:0> 4/5r
+=> (4/5)
+irb(main):004:0> 4/5.0
+=> 0.8
+irb(main):005:0> (4/5r).to_f
+=> 0.8
+```
+
+以下, 解説より抜粋.
+
+* 整数 (Integer) 同士の演算結果は整数となり, 小数点以下は丸められる為, 選択肢 1 の結果は 0 になる
+* 選択肢 3 の 4/5r の結果は Rational クラスのオブジェクトを生成し, (4/5r).to_f とすれば 0.8 となる
+
+### 文法 (16)
+
+Q4. 以下のコードを実行するとどうなるか.
+
+```ruby
+class Err1 < StandardError; end
+class Err2 < Err1; end
+begin
+  raise Err2
+rescue => e
+  puts 'StandardError'
+rescue Err2 => ex
+  puts ex.class
+end
+```
+
+以下, 解答.
+
+>2. StandardError と表示される
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> class Err1 < StandardError; end
+=> nil
+irb(main):002:0> class Err2 < Err1; end
+=> nil
+irb(main):003:0> begin
+irb(main):004:1*   raise Err2
+irb(main):005:1> rescue => e
+irb(main):006:1>   puts 'StandardError'
+irb(main):007:1> rescue Err2 => ex
+irb(main):008:1>   puts ex.class
+irb(main):009:1> end
+StandardError
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* 設問において, begin 節の raise で発生する例外オブジェクトは Err2 である
+* `rescue Err2 => ex` では Err2, もしくは Err2 を継承した例外オブジェクトを対象とするように書かれているが...
+* `rescue => e` にて `StandardError` から派生する全ての例外を捕捉する為, この `rescue => e` で処理される
+
+ﾌﾑﾌﾑ.

--- a/2018/07/26.md
+++ b/2018/07/26.md
@@ -1,0 +1,156 @@
+# 2018/07/26 今日のるびぃ
+
+## 今日のるびぃ ~ Ruby 技術者認定試験合格教本 （Silver/Gold 対応） Ruby 公式資格教科書 模擬試験 (16) 文法 (6) ~
+
+irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### 文法 (17)
+
+Q5. 以下のコードを実行するとどうなるか.
+
+```ruby
+class C
+  VAR = 0
+  def VAR=v
+    VAR = v
+  end
+  def VAR
+    VAR
+  end
+end
+
+c = C.new
+c.VAR = 3
+puts c.VAR
+```
+
+以下, 解答.
+
+> 1. 4 行目でエラーが発生
+
+以下, irb にて確認.
+
+```ruby
+irb(main):010:0> class C
+irb(main):011:1>   VAR = 0
+irb(main):012:1>   def VAR=v
+irb(main):013:2>     VAR = v
+irb(main):014:2>   end
+irb(main):015:1>   def VAR
+irb(main):016:2>     VAR
+irb(main):017:2>   end
+irb(main):018:1> end
+SyntaxError: (irb):13: dynamic constant assignment
+    VAR = v
+...
+```
+
+以下, 解説より抜粋.
+
+* メソッド内の定数更新は, そもそもコンパイルエラーとなる
+
+### 文法 (18)
+
+Q6. 以下のコードの中で文法として正しいものを全て選べ.
+
+以下, 解答.
+
+>1. 1.upto 5 do puts x end
+>2. 1.upto(5) do puts x end
+>4. 1.upto(5) { puts x }
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> 1.upto 5 do |x| puts x end
+1
+2
+3
+4
+5
+=> 1
+irb(main):002:0> 1.upto(5) do |x| puts x end
+1
+2
+3
+4
+5
+=> 1
+irb(main):003:0> 1.upto(5) { |x| puts x }
+1
+2
+3
+4
+5
+=> 1
+irb(main):004:0> 1.upto 5 { |x| puts x }
+SyntaxError: (irb):4: syntax error, unexpected '{', expecting end-of-input
+1.upto 5 { |x| puts x }
+          ^
+```
+
+以下, 解説より抜粋.
+
+* ブロック引数を `{ ... }` で囲む場合には引数の `()` を省略することは出来ない
+* `do ... end` で囲む場合には, 引数の `()` を省略することは出来る
+
+### 文法 (19)
+
+Q7. 以下の実行結果になるように [ x ] に記述する適切なコードを全て選べ.
+
+```ruby
+# コード
+[ x ]
+tag(:p) {'Hello, World.'}
+
+# 実行結果
+<p>Hello, World.</p>
+```
+
+以下, 解答.
+
+```ruby
+# 解答 1
+def tag(name)
+  puts "<#{name}>#{yield}<#{name}>"
+end
+
+# 解答 2
+def tag(name, &block)
+  puts "<#{name}>#{block.call}<#{name}>"
+end
+```
+
+以下, irb にて確認.
+
+```ruby
+# 解答 1
+irb(main):001:0> def tag(name)
+irb(main):002:1>   puts "<#{name}>#{yield}<#{name}>"
+irb(main):003:1> end
+=> :tag
+irb(main):004:0> tag(:p) {'Hello, World.'}
+<p>Hello, World.<p>
+=> nil
+# 解答 2
+irb(main):005:0> def tag(name, &block)
+irb(main):006:1>   puts "<#{name}>#{block.call}<#{name}>"
+irb(main):007:1> end
+=> :tag
+irb(main):008:0> tag(:p) {'Hello, World.'}
+<p>Hello, World.<p>
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* ブロック付きメソッドから呼び出し元のブロックを実行するには, `yield` を使うか, 引数に `&` を付けた変数を定義し, ブロックを Proc オブジェクトとして取得してから, Proc#call を呼び出す
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* 可変長引数にはデフォルト値の指定出来ない
* 引数は配列として扱われる
* 可変長引数は一つのメソッドに一つしか指定出来ない
* 整数 (Integer) 同士の演算結果は整数となり, 小数点以下は丸められる為, 選択肢 1 の結果は 0 になる
* メソッド内の定数更新は, そもそもコンパイルエラーとなる
* ブロック引数を `{ ... }` で囲む場合には引数の `()` を省略することは出来ない
* `do ... end` で囲む場合には, 引数の `()` を省略することは出来る
* ブロック付きメソッドから呼び出し元のブロックを実行するには, `yield` を使うか, 引数に `&` を付けた変数を定義し, ブロックを Proc オブジェクトとして取得してから, Proc#call を呼び出す