### PR TITLE
2018/08/01 分を追加

### DIFF
--- a/2018/08/01.md
+++ b/2018/08/01.md
@@ -1,0 +1,194 @@
+# 2018/08/01 今日のるびぃ
+
+## 今日のるびぃ ~ Ruby 技術者認定試験合格教本 （Silver/Gold 対応） Ruby 公式資格教科書 基礎力確認試験 (2) オブジェクト指向 (2) ~
+
+irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### オブジェクト指向 (6)
+
+Q17. 以下のコードを実行すると何が表示されるか.
+
+```ruby
+module Mod1; end
+module Mod2; end
+class Cls1
+  prepend Mod1
+end
+class Cls2 < Cls1
+  prepend Mod2
+end
+p Cls2.ancestors
+```
+
+以下, 解答.
+
+> 2. [Mod2, Cls2, Mod1, Cls1, Object, Kernel, BasicObject]
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> module Mod1; end
+=> nil
+irb(main):002:0> module Mod2; end
+=> nil
+irb(main):003:0> class Cls1
+irb(main):004:1>   prepend Mod1
+irb(main):005:1> end
+=> Cls1
+irb(main):006:0> class Cls2 < Cls1
+irb(main):007:1>   prepend Mod2
+irb(main):008:1> end
+=> Cls2
+irb(main):009:0> p Cls2.ancestors
+[Mod2, Cls2, Mod1, Cls1, Object, Kernel, BasicObject]
+=> [Mod2, Cls2, Mod1, Cls1, Object, Kernel, BasicObject]
+```
+
+以下, 解説より抜粋.
+
+* prepend されたモジュールは, prepend した対象のクラスよりも先にメソッドの探索が行われる
+
+### オブジェクト指向 (7)
+
+Q18. 以下の実行結果になるように, [ x ] に記述する適切なコードを全て選べ.
+
+```ruby
+# コード　
+class Example
+  def hoge
+    self.piyo
+  end
+  [ x ]
+  def piyo
+    puts 'piyo'
+  end
+end
+Example.new.hoge
+
+# 実行結果
+piyo
+```
+
+以下, 解答.
+
+> 2. protected
+> 3. public
+> 4. 何も記述しない
+
+以下, 解説より抜粋.
+
+* `self.piyo` と `piyo` メソッドに `self` レシーバーをつけている為, `piyo` メソッドが `private` だとエラーとなる
+* `private` 以外の `protected`, `public`, 何も記述しない場合は `self.piyo` で呼び出すことが出来る
+
+### オブジェクト指向 (8)
+
+Q19. 以下のコードを実行すると何が表示されるか.
+
+```ruby
+class Object
+  X = 'X'
+  def self.const_missing a
+    p "#{a}"
+  end
+end
+Y
+```
+
+以下, 解答.
+
+> 2. "Y"
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> class Object
+irb(main):002:1>   X = 'X'
+irb(main):003:1>   def self.const_missing a
+irb(main):004:2>     p "#{a}"
+irb(main):005:2>   end
+irb(main):006:1> end
+=> :const_missing
+irb(main):007:0> Y
+"Y"
+=> "Y"
+```
+
+以下, 解説より抜粋.
+
+* 定数が見つからない場合, `Module#const_missing` が実行される
+* `Module#const_missing` はオーバーライトが可能である
+* 設問コードには定数 `Y` は存在しておらず, Object クラスには const_missing が定義されている
+* トップレベルは Object クラスなので, Object クラスに定義された const_missing が実行され `Y` が表示される
+
+### オブジェクト指向 (9)
+
+Q20. 以下の実行結果になるように, [ x ] に記述する適切なコードを選べ.
+
+```ruby
+# コード
+class C
+  def hoge
+    puts 'A'
+  end
+end
+
+module M
+  refine C do
+    def hoge
+      puts 'B'
+    end
+  end
+end
+
+c = C.new
+c.hoge
+[ x ] M
+c.hoge
+
+# 実行結果
+A
+B
+```
+
+以下, 解答.
+
+> 4. using
+
+以下, irb にて確認.
+
+```ruby
+irb(main):001:0> class C
+irb(main):002:1>   def hoge
+irb(main):003:2>     puts 'A'
+irb(main):004:2>   end
+irb(main):005:1> end
+=> :hoge
+irb(main):006:0> 
+irb(main):007:0* module M
+irb(main):008:1>   refine C do
+irb(main):009:2*     def hoge
+irb(main):010:3>       puts 'B'
+irb(main):011:3>     end
+irb(main):012:2>   end
+irb(main):013:1> end
+=> #<refinement:C@M>
+irb(main):014:0> c = C.new
+=> #<C:0x00562753ea6098>
+irb(main):015:0> c.hoge; using M; c.hoge
+A
+B
+=> nil
+```
+
+以下, 解説より抜粋.
+
+* refine で再定義したメソッドを有効にするには, using を利用する
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* prepend されたモジュールは, prepend した対象のクラスよりも先にメソッドの探索が行われる
* `private` 以外の `protected`, `public`, 何も記述しない場合は `self.piyo` で呼び出すことが出来る
* 定数が見つからない場合, `Module#const_missing` が実行される
* `Module#const_missing` はオーバーライトが可能である