### PR TITLE
2018/08/05 分を追加

### DIFF
--- a/2018/08/05.md
+++ b/2018/08/05.md
@@ -1,0 +1,158 @@
+# 2018/08/05 今日のるびぃ
+
+## 今日のるびぃ ~ 例外 ~
+
+例外の理解がイマイチなので, パターン別に挙動を確認する. 尚, irb に動作確認環境は以下の通り.
+
+```ruby
+$ ruby --version
+ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
+$ irb --version
+irb 0.9.6(09/06/30)
+```
+
+### パターン 1
+
+```ruby
+# パターン 1-1 (StandardError を継承している場合)
+class MyError1 < StandardError; end
+
+begin
+  raise MyError1
+rescue => e
+  puts "StandardError!!"
+end
+puts "End"
+
+# irb での出力結果
+... 略 ...
+StandardError!!
+=> nil
+irb(main):008:0> puts "End"
+End
+=> nil
+
+# パターン 1-2 (StandardError を継承していない場合)
+class MyError1; end
+
+begin
+  raise MyError1
+rescue StandardError => e
+  puts "StandardError!!"
+end
+puts "End"
+
+# irb での出力結果
+StandardError!!
+=> nil
+irb(main):008:0> puts "End"
+End
+=> nil
+```
+
+* 任意のクラス (例: MyError1) が StandardError を継承している場合には, StandardError で例外が捕捉される
+* StandardError を明示的に継承していない場合でも, StandardError で例外が捕捉される
+
+### パターン 2
+
+```ruby
+# パターン 2
+class MyError1 < StandardError; end
+
+begin
+  raise MyError1
+rescue MyError1 => e
+  puts "MyError1"
+rescue StandardError => e
+  puts "StandardError!!"
+end
+puts "End"
+
+# irb での出力結果
+... 略 ...
+MyError1
+=> nil
+irb(main):010:0> puts "End"
+End
+=> nil
+```
+
+* 例外オブジェクトのクラスは MyError1 なので, 7 行目の MyError1 で rescue される
+* StandardError を継承している場合でも, 例外オブジェクトのクラス名で rescue されていれば, そちらの方が優先される
+
+### パターン 3
+
+```ruby
+# パターン 3
+class MyError1 < StandardError; end
+class MyError2 < MyError1; end
+
+begin
+  raise MyError1
+rescue MyError2 => e
+  puts "MyError1"
+rescue StandardError => e
+  puts "StandardError!!"
+end
+puts "End"
+
+# irb での出力結果
+... 略 ...
+StandardError!!
+=> nil
+irb(main):011:0> puts "End"
+End
+=> nil
+```
+
+* 例外オブジェクトのクラスは MyError1 なので, MyError2 では rescue 出来ずに, その次の StandardError で rescue される
+
+### パターン 4
+
+```ruby
+# パターン 4
+class MyError1 < StandardError; end
+class MyError2 < MyError1; end
+
+begin
+  raise MyError2
+rescue MyError1 => e
+  puts "MyError1"
+rescue StandardError => e
+  puts "StandardError!!"
+end
+puts "End"
+
+# irb での出力結果
+... 略 ...
+MyError1
+=> nil
+irb(main):011:0> puts "End"
+End
+=> nil
+```
+
+* 例外オブジェクトのクラスは MyError2 だが, MyError2 は MyError1 を継承している為, MyError1 でも rescue される
+
+### パターン 5
+
+```ruby
+# パターン 5
+class Error1 < StandardError; end
+class Error2 < Error1; end
+begin
+  raise Error2
+rescue Error1 => ex
+  puts ex.class
+end
+
+# irb での出力結果
+... 略 ...
+Error2
+=> nil
+```
+
+* 例外オブジェクトのクラスは MyError2 だが, MyError2 は MyError1 を継承している為, MyError1 でも rescue される
+* また `ex.class` で例外オブジェクトのクラス名を取得している
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
* 任意のクラス (例: MyError1) が StandardError を継承している場合には, StandardError で例外が捕捉される
* StandardError を明示的に継承していない場合でも, StandardError で例外が捕捉される
* StandardError を継承している場合でも, 例外オブジェクトのクラス名で rescue されていれば, そちらの方が優先される